### PR TITLE
Donor and Food List Tabs

### DIFF
--- a/src/api/apiHelpers.js
+++ b/src/api/apiHelpers.js
@@ -20,3 +20,21 @@ export function createVolData(
     captainsNotes,
   };
 }
+
+export function createDonorData(
+  id,
+  email,
+  firstName,
+  address,
+  postalCode,
+  pickUpNotes,
+) {
+  return {
+    id,
+    email,
+    firstName,
+    address,
+    postalCode,
+    pickUpNotes,
+  };
+}

--- a/src/api/apiMethods.js
+++ b/src/api/apiMethods.js
@@ -1,5 +1,5 @@
 import api from './apiBase';
-import { createVolData } from './apiHelpers';
+import { createVolData, createDonorData } from './apiHelpers';
 
 export async function getLoggedIn() {
   return api.get('/v1/auth/me')
@@ -63,4 +63,56 @@ export async function updateVolunteer(neighbourhood, userId, fields, setError) {
         setError('Site / Network Error, please try again later.');
       }
     });
+}
+
+export async function getDonors(neighbourhood) {
+  let donorsAcc = [];
+
+  return api(`/v1/neighbourhoods/${neighbourhood}/donors/`)
+    .then((response) => {
+      const donors = response.data.message;
+
+      donors.forEach((record) => {
+        donorsAcc = [
+          ...donorsAcc,
+          createDonorData(
+            record.id,
+            record.email,
+            record['first name'],
+            record.address,
+            record['postal code'],
+            record['pickup notes'],
+          ),
+        ];
+      });
+
+      return donorsAcc;
+    })
+    .catch(() => []);
+}
+
+export async function getFoodDrives(neighbourhood) {
+  let foodDrivesAcc = [];
+
+  return api(`/v1/neighbourhoods/${neighbourhood}/foodDrives/`)
+    .then((response) => {
+      const foodDrives = response.data.message;
+
+      foodDrives.forEach((record) => {
+        foodDrivesAcc = [
+          ...foodDrivesAcc,
+          createDonorData(
+            record.id,
+            record.email,
+            record['first name'],
+            record.address,
+            record['postal code'],
+            record['pickup notes'],
+          ),
+        ];
+      });
+
+      return foodDrivesAcc;
+    })
+    .catch(() => []);
 }

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -10,13 +10,15 @@ import TabPanel from '@mui/lab/TabPanel';
 import Header from './Header';
 import VolunteerList from './VolunteerList';
 import DonorList from './DonorList';
-import { getVolunteers } from '../api/apiMethods';
+import { getVolunteers, getDonors, getFoodDrives } from '../api/apiMethods';
 import { UserContext } from '../contexts/UserContext';
 
 function Dashboard() {
   const { user } = useContext(UserContext);
 
   const [volunteerListRows, setVolunteerListRows] = useState([]);
+  const [donorListRows, setDonorListRows] = useState([]);
+  const [foodDriveListRows, setFoodDriveListRows] = useState([]);
 
   const [selectedTab, setSelectedTab] = React.useState('1');
 
@@ -29,6 +31,12 @@ function Dashboard() {
       if ('neighbourhoods' in user) {
         const volunteers = await getVolunteers(user.neighbourhoods[0]);
         setVolunteerListRows(volunteers);
+
+        const donors = await getDonors(user.neighbourhoods[0]);
+        setDonorListRows(donors);
+
+        const foodDrives = await getFoodDrives(user.neighbourhoods[0]);
+        setFoodDriveListRows(foodDrives);
       }
     };
     getData();
@@ -77,10 +85,10 @@ function Dashboard() {
               <VolunteerList volunteerRows={volunteerListRows} />
             </TabPanel>
             <TabPanel value="2">
-              <DonorList />
+              <DonorList donorRows={donorListRows} />
             </TabPanel>
             <TabPanel value="3">
-              <DonorList isFoodDriveList />
+              <DonorList donorRows={foodDriveListRows} />
             </TabPanel>
           </TabContext>
         </Grid>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -10,6 +10,7 @@ import TabPanel from '@mui/lab/TabPanel';
 import Header from './Header';
 import VolunteerList from './VolunteerList';
 import DonorList from './DonorList';
+import DriveList from './DriveList';
 import { getVolunteers, getDonors, getFoodDrives } from '../api/apiMethods';
 import { UserContext } from '../contexts/UserContext';
 
@@ -88,7 +89,7 @@ function Dashboard() {
               <DonorList donorRows={donorListRows} />
             </TabPanel>
             <TabPanel value="3">
-              <DonorList donorRows={foodDriveListRows} />
+              <DriveList driveRows={foodDriveListRows} />
             </TabPanel>
           </TabContext>
         </Grid>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -9,6 +9,7 @@ import TabPanel from '@mui/lab/TabPanel';
 
 import Header from './Header';
 import VolunteerList from './VolunteerList';
+import DonorList from './DonorList';
 import { getVolunteers } from '../api/apiMethods';
 import { UserContext } from '../contexts/UserContext';
 
@@ -16,7 +17,6 @@ function Dashboard() {
   const { user } = useContext(UserContext);
 
   const [volunteerListRows, setVolunteerListRows] = useState([]);
-  // const [donorListRows, setDonorListRows] = useState([]);
 
   const [selectedTab, setSelectedTab] = React.useState('1');
 
@@ -25,13 +25,13 @@ function Dashboard() {
   };
 
   useEffect(() => {
-    const getVols = async () => {
+    const getData = async () => {
       if ('neighbourhoods' in user) {
         const volunteers = await getVolunteers(user.neighbourhoods[0]);
         setVolunteerListRows(volunteers);
       }
     };
-    getVols();
+    getData();
   }, [user]);
 
   return (
@@ -69,18 +69,19 @@ function Dashboard() {
                 indicatorColor="secondary"
               >
                 <Tab label="Volunteer List" value="1" />
-                {/* <Tab label="Donor List" value="2" /> */}
+                <Tab label="Donor List" value="2" />
+                <Tab label="Food Drive List" value="3" />
               </TabList>
             </Box>
             <TabPanel value="1">
               <VolunteerList volunteerRows={volunteerListRows} />
             </TabPanel>
-            {/* <TabPanel value="2">
-              <CardList contactListRows={donorListRows} isDonorList />
-            </TabPanel> */}
-            {/* <TabPanel value="3">
-              <Stats volunteerListRows={volunteerListRows} donorListRows={donorListRows} />
-            </TabPanel> */}
+            <TabPanel value="2">
+              <DonorList />
+            </TabPanel>
+            <TabPanel value="3">
+              <DonorList isFoodDriveList />
+            </TabPanel>
           </TabContext>
         </Grid>
       </Grid>

--- a/src/components/DonorList.jsx
+++ b/src/components/DonorList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React from 'react';
 import { styled } from '@mui/material/styles';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -11,9 +11,6 @@ import TableCell, { tableCellClasses } from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import Paper from '@mui/material/Paper';
 
-import { getDonors, getFoodDrives } from '../api/apiMethods';
-import { UserContext } from '../contexts/UserContext';
-
 const HeaderTableCell = styled(TableCell)(() => ({
   [`&.${tableCellClasses.head}`]: {
     fontWeight: 'bold',
@@ -21,29 +18,9 @@ const HeaderTableCell = styled(TableCell)(() => ({
   },
 }));
 
-function DonorList({ isFoodDriveList }) {
+function DonorList({ donorRows }) {
   const [page, setPage] = React.useState(0);
   const ROWS_PER_PAGE = 10;
-
-  const [donorListRows, setDonorListRows] = useState([]);
-  const [foodDriveListRows, setFoodDriveListRows] = useState([]);
-
-  const { user } = useContext(UserContext);
-
-  useEffect(() => {
-    const getData = async () => {
-      if ('neighbourhoods' in user) {
-        const donors = await getDonors(user.neighbourhoods[0]);
-        setDonorListRows(donors);
-
-        const foodDrives = await getFoodDrives(user.neighbourhoods[0]);
-        setFoodDriveListRows(foodDrives);
-      }
-    };
-    getData();
-  }, [user]);
-
-  const donorRows = isFoodDriveList ? foodDriveListRows : donorListRows;
 
   const handleChangePage = (event, newPage) => {
     setPage(newPage);

--- a/src/components/DriveList.jsx
+++ b/src/components/DriveList.jsx
@@ -18,7 +18,7 @@ const HeaderTableCell = styled(TableCell)(() => ({
   },
 }));
 
-function DonorList({ donorRows }) {
+function DriveList({ driveRows }) {
   const [page, setPage] = React.useState(0);
   const ROWS_PER_PAGE = 10;
 
@@ -36,13 +36,16 @@ function DonorList({ donorRows }) {
           <Table aria-label="simple table">
             <TableHead>
               <TableRow>
-                <HeaderTableCell>Address</HeaderTableCell>
+                <HeaderTableCell>Name</HeaderTableCell>
+                <HeaderTableCell align="right">Email</HeaderTableCell>
+                <HeaderTableCell align="right">Address</HeaderTableCell>
+                <HeaderTableCell align="right">Postal Code</HeaderTableCell>
                 <HeaderTableCell align="right">Pick Up Notes</HeaderTableCell>
               </TableRow>
             </TableHead>
 
             <TableBody>
-              {donorRows
+              {driveRows
                 ?.slice(page * ROWS_PER_PAGE, page * ROWS_PER_PAGE + ROWS_PER_PAGE)
                 .map((row) => (
                   <TableRow
@@ -53,9 +56,25 @@ function DonorList({ donorRows }) {
                   >
                     <TableCell
                       sx={{ color: 'text.secondary' }}
-                      align="left"
+                      component="th"
+                      scope="row"
                     >
-                      {`${row.address}${row.postalCode ? " "+row.postalCode : ""}`}
+                      {row.firstName}
+                    </TableCell>
+                    <TableCell sx={{ color: 'text.secondary' }} align="right">
+                      {row.email}
+                    </TableCell>
+                    <TableCell
+                      sx={{ color: 'text.secondary' }}
+                      align="right"
+                    >
+                      {row.address}
+                    </TableCell>
+                    <TableCell
+                      sx={{ color: 'text.secondary' }}
+                      align="right"
+                    >
+                      {row.postalCode}
                     </TableCell>
                     <TableCell
                       sx={{ color: 'text.secondary' }}
@@ -71,7 +90,7 @@ function DonorList({ donorRows }) {
         <TablePagination
           rowsPerPageOptions={[ROWS_PER_PAGE]}
           component="div"
-          count={donorRows?.length}
+          count={driveRows?.length}
           rowsPerPage={ROWS_PER_PAGE}
           page={page}
           onPageChange={handleChangePage}
@@ -81,4 +100,4 @@ function DonorList({ donorRows }) {
   );
 }
 
-export default DonorList;
+export default DriveList;

--- a/src/components/VolunteerList.jsx
+++ b/src/components/VolunteerList.jsx
@@ -49,7 +49,7 @@ function VolunteerList({ volunteerRows }) {
 
             <TableBody>
               {volunteerRows
-                .slice(page * ROWS_PER_PAGE, page * ROWS_PER_PAGE + ROWS_PER_PAGE)
+                ?.slice(page * ROWS_PER_PAGE, page * ROWS_PER_PAGE + ROWS_PER_PAGE)
                 .map((row) => <VolunteerListRow key={row.email} row={row} />)}
             </TableBody>
           </Table>
@@ -57,7 +57,7 @@ function VolunteerList({ volunteerRows }) {
         <TablePagination
           rowsPerPageOptions={[ROWS_PER_PAGE]}
           component="div"
-          count={volunteerRows.length}
+          count={volunteerRows?.length}
           rowsPerPage={ROWS_PER_PAGE}
           page={page}
           onPageChange={handleChangePage}


### PR DESCRIPTION
Right now the FE makes a call on load to all three /vols, /donors, /fooddrives
- can potentially limit the number of API calls to only on tab click if API gets overloaded

Also, currently the donor tab and food drive tab look exactly the same, but this might change when different data is pulled for the food drives